### PR TITLE
fix(ci): use rm -rf for robust data cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           s3cmd get s3://openipdb/openipdb.ipdb /tmp/openipdb.ipdb
           ls -al /tmp/openipdb.ipdb
-          rm -r ./data
+          rm -rf ./data
           pnpm install
           pnpm run build
       - name: Push


### PR DESCRIPTION
This PR implements a robust directory cleanup for `./data` by using `rm -rf` instead of `rm -r` in the GitHub Actions build workflow. This avoids potential workflow failures if the `./data` directory does not exist prior to the build run.